### PR TITLE
Rename the 'q' alias to ':q'

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -28,7 +28,7 @@ alias cls='clear'
 alias edit="$EDITOR"
 alias pager="$PAGER"
 
-alias q='exit'
+alias :q='exit'
 
 alias irc="$IRC_CLIENT"
 


### PR DESCRIPTION
It's too easy to mistype 'q<CR>' when using the 'a' alias (alias for `fasd -a`) and then your terminal closes.  I understand some people want this command, because it's similar to the vim `:q` command.  So this compromise is to make it even more similar rather than removing it outright. 

Also, I'm assuming that this file is used by the capi team's sprout process to set up machines, but I don't see any direct evidence to that in the `cloudfoundry/sprout-capi` repo.